### PR TITLE
Switch option parsing to argparse

### DIFF
--- a/ietf_gh_utils.py
+++ b/ietf_gh_utils.py
@@ -20,9 +20,17 @@ def verify_users(g, user):
             raise SystemExit('User "%s" does not exist"' % (u,))
     return 1
 
-def gh_login(np):
-    """Login to Github  |np| is colon-separated name and password, if omitted
+def add_gh_auth_arguments(parser):
+    """Add arguments needed for logging into Github to the
+    argparse.ArgumentParser."""
+    group = parser.add_argument_group('Github Auth')
+    group.add_argument('--np', '-n', metavar='name:pass', required=True,
+                       help="Github login credentials")
+
+def gh_login(args):
+    """Login to Github  |args.np| is colon-separated name and password, if omitted
     either one will be prompted-for.  Returns the handle and the username"""
+    np = args.np
     name = None
     passwd = None
     if np is not None:

--- a/mk-ietf-draft
+++ b/mk-ietf-draft
@@ -1,54 +1,24 @@
 #! /usr/bin/env python
 """
 Create an IETF WG repository for an I-D
-
-Flags:
-    --wg WGNAME
-    --doc DOCNAME
-    --editor GH_ID (can be repeated, must be at least once)
-    --n name:pass Github login credentials
 """
 
-import getopt, sys
+import argparse, sys
 import ietf_gh_utils as UTILS
 
-# Set defaults
-WGNAME = None
-DOCNAME = None
-EDITORS = []
-NAMEPASS = None
+# Parse command line.
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--wg', '-w', required=True)
+parser.add_argument('--doc', '-d', metavar='DOCNAME', required=True)
+parser.add_argument('--editor', '-e', metavar='GH_ID', action='append',
+                    required=True,
+                    help="(can be repeated, must be at least once)")
+UTILS.add_gh_auth_arguments(parser)
+args = parser.parse_args(sys.argv[1:])
 
-# Parse JCL.
-try:
-    opts, args = getopt.getopt(sys.argv[1:], "hw:d:e:n:",
-                              ["help", "wg=", "doc=", "editor=", "np="])
-except getopt.GetoptError as err:
-    print str(err)
-    raise SystemExit
-if args or len(args) != 0:
-    raise SystemExit("Usage error; try --help for help");
-for o,a in opts:
-    if o in ('-h', '--help'):
-        print __doc__
-        raise SystemExit
-    if o in ("-w", "--wg"):
-        WGNAME = a
-    elif o in ("-d", "--doc"):
-        DOCNAME = a
-    elif o in ("-e", "--editor"):
-        EDITORS += [ a ]
-    elif o in ("-n", "--np"):
-        NAMEPASS = a
-    else:
-        assert False, "Unhandled option: " + o
-
-# Verify flag syntax.
-if not WGNAME:
-    raise SystemExit("-w/--wg flag required; use -h for help")
-if not DOCNAME:
-    raise SystemExit("-d/--doc flag required; use -h for help")
-if len(EDITORS) == 0:
-    raise SystemExit( "-e/--editor flag required; use -h for help")
+WGNAME = args.wg
+DOCNAME = args.doc
+EDITORS = args.editor
 
 # Fix doc name: remove draft- ietf- $WGNAME- from front
 while True:
@@ -63,7 +33,7 @@ if len(DOCNAME) == 0:
     raise SystemExit("Docname is all prefixes!")
 
 # Login
-G,USER = UTILS.gh_login(NAMEPASS)
+G,USER = UTILS.gh_login(args)
 
 # Verify user names
 if not UTILS.verify_users(G, EDITORS):

--- a/mk-ietf-wg
+++ b/mk-ietf-wg
@@ -1,20 +1,13 @@
 #! /usr/bin/env python
 """
 Create an IETF WG organization and infrastructure
-
-Flags:
-    --wg WGNAME
-    --chair GH_ID (can be repeated, must be at least once)
-    --ad GH_ID (can be repeated, must be at least once)
-    --np name:pass Github login credentials
 """
 
 import argparse, sys
 import ietf_gh_utils as UTILS
 
 # Parse command line.
-parser = argparse.ArgumentParser(
-    description="Create an IETF WG organization and infrastructure")
+parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--wg', '-w', required=True)
 parser.add_argument('--chair', '-c', metavar='GH_ID', action='append', required=True,
                     help="(can be repeated, must be at least once)")

--- a/mk-ietf-wg
+++ b/mk-ietf-wg
@@ -9,49 +9,26 @@ Flags:
     --np name:pass Github login credentials
 """
 
-import getopt, sys
+import argparse, sys
 import ietf_gh_utils as UTILS
 
-# Set defaults
-WGNAME = None
-CHAIRS = []
-ADS = []
-NAMEPASS = None
+# Parse command line.
+parser = argparse.ArgumentParser(
+    description="Create an IETF WG organization and infrastructure")
+parser.add_argument('--wg', '-w', required=True)
+parser.add_argument('--chair', '-c', metavar='GH_ID', action='append', required=True,
+                    help="(can be repeated, must be at least once)")
+parser.add_argument('--ad', '-a', metavar='GH_ID', action='append', required=True,
+                    help="(can be repeated, must be at least once)")
+UTILS.add_gh_auth_arguments(parser)
+args = parser.parse_args(sys.argv[1:])
 
-# Parse JCL.
-try:
-    opts, args = getopt.getopt(sys.argv[1:], "hw:c:a:n:",
-                              ["help", "wg=", "chair=", "ad=", "np="])
-except getopt.GetoptError as err:
-    print str(err)
-    raise SystemExit
-if args or len(args) != 0:
-    raise SystemExit("Usage error; try --help for help");
-for o,a in opts:
-    if o in ('-h', '--help'):
-        print __doc__
-        raise SystemExit
-    if o in ("-w", "--wg"):
-        WGNAME = a
-    elif o in ("-c", "--chair"):
-        CHAIRS += [ a ]
-    elif o in ("-a", "--ad"):
-        ADS += [ a ]
-    elif o in ("-n", "--np"):
-        NAMEPASS = a
-    else:
-        assert False, "Unhandled option: " + o
-
-# Verify some things, like flag usage.
-if not WGNAME:
-    raise SystemExit("-w/--wg flag required; use -h for help")
-if len(CHAIRS) == 0:
-    raise SystemExit("-c/--chair flag required; use -h for help")
-if len(ADS) == 0:
-    raise SystemExit( "-a/--ad flag required; use -h for help")
+WGNAME = args.wg
+CHAIRS = args.chair
+ADS = args.ad
 
 # Login
-G,USER = UTILS.gh_login(NAMEPASS)
+G,USER = UTILS.gh_login(args)
 
 # Verify user names
 if not UTILS.verify_users(G, CHAIRS) or not UTILS.verify_users(G, ADS):

--- a/mk-ind-draft
+++ b/mk-ind-draft
@@ -1,58 +1,28 @@
 #! /usr/bin/env python
 """
 Create an IETF WG repository for an I-D
-
-Flags:
-    --asis Don't try to standardize the name
-    --doc DOCNAME
-    --editor GH_ID (can be repeated, must be at least once)
-    --n name:pass Github login credentials
 """
 
-import getopt, sys
+import argparse, sys
 import ietf_gh_utils as UTILS
 
-# Set defaults
-WGNAME = None
-DOCNAME = None
-EDITORS = []
-NAMEPASS = None
-ASIS = False
+# Parse command line.
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--doc', '-d', metavar='DOCNAME', required=True)
+parser.add_argument('--asis', '-a', action='store_true',
+                    help="Don't try to standardize the name")
+UTILS.add_gh_auth_arguments(parser)
+args = parser.parse_args(sys.argv[1:])
 
-# Parse JCL.
-try:
-    opts, args = getopt.getopt(sys.argv[1:], "ahd:n:",
-                              ["asis", "help", "doc=", "np="])
-except getopt.GetoptError as err:
-    print str(err)
-    raise SystemExit
-if args or len(args) != 0:
-    raise SystemExit("Usage error; try --help for help");
-for o,a in opts:
-    if o in ('-h', '--help'):
-        print __doc__
-        raise SystemExit
-    if o in ("-a", "--asis"):
-        ASIS = True
-    elif o in ("-d", "--doc"):
-        DOCNAME = a
-    elif o in ("-n", "--np"):
-        NAMEPASS = a
-    else:
-        assert False, "Unhandled option: " + o
+DOCNAME = args.doc
+ASIS = args.asis
 
 # Login
-G,USER = UTILS.gh_login(NAMEPASS)
+G,USER = UTILS.gh_login(args)
 
 # For individual draft, the WGNAME is the USER name
 WGNAME = USER
 EDITORS = [ USER ]
-
-# Verify flag syntax.
-if not DOCNAME:
-    raise SystemExit("-d/--doc flag required; use -h for help")
-if len(EDITORS) == 0:
-    raise SystemExit( "-e/--editor flag required; use -h for help")
 
 # Fix doc name: remove draft- ietf- $WGNAME- from front
 if not ASIS:


### PR DESCRIPTION
This noticeably shortens the argument parsing code and moves control of the github login argument to ietf_gh_utils.py in preparation for allowing callers to pass an access token instead of a password, which will allow 2FA users to call these scripts.