### PR TITLE
Initialize the repository inside the script.

### DIFF
--- a/mk-ietf-draft
+++ b/mk-ietf-draft
@@ -3,8 +3,10 @@
 Create an IETF WG repository for an I-D
 """
 
-import argparse, sys
+import argparse
+import sys
 import ietf_gh_utils as UTILS
+import repo_utils
 
 # Parse command line.
 parser = argparse.ArgumentParser(description=__doc__)
@@ -24,7 +26,7 @@ EDITORS = args.editor
 
 # Fix doc name: remove draft- ietf- $WGNAME- from front
 while True:
-    for prefix in ( 'draft-', 'ietf-', WGNAME+'-'):
+    for prefix in ('draft-', 'ietf-', WGNAME+'-'):
         found = False
         if DOCNAME.startswith(prefix):
             DOCNAME = DOCNAME[len(prefix):]
@@ -35,7 +37,7 @@ if len(DOCNAME) == 0:
     raise SystemExit("Docname is all prefixes!")
 
 # Login
-G,USER = UTILS.gh_login(args)
+G, USER = UTILS.gh_login(args)
 
 # Verify user names
 if not UTILS.verify_users(G, EDITORS):
@@ -43,7 +45,7 @@ if not UTILS.verify_users(G, EDITORS):
 
 # See if organization exists.
 WGNAME = UTILS.fix_wg_name(WGNAME)
-DOC="draft-" + WGNAME + "-" + DOCNAME
+DOC = "draft-" + WGNAME + "-" + DOCNAME
 ORG = 'ietf-wg-' + WGNAME
 if not UTILS.org_exists(G, ORG):
     raise SystemExit("Organization not found; try mk-ietf-wg")
@@ -52,19 +54,19 @@ o = G.get_organization(ORG)
 # Create an editors team and populate it
 editors = o.create_team(DOC, privacy='closed')
 editors.add_membership(G.get_user(USER))
-done = [ USER ]
+done = [USER]
 for e in EDITORS:
     if e not in done:
         editors.add_membership(G.get_user(e))
-        done += [ e ]
+        done += [e]
 # Add the "owners" people?
 
 # Create repository draft-$WGNAME-$DOCNAME
 repo = o.create_repo(DOC,
-        description="Repository for " + DOC + " draft",
-        has_issues=True, # Probably the default, but this is funny
-        team_id=editors.id
-        )
+                     description="Repository for " + DOC + " draft",
+                     has_issues=True,  # Probably the default, but this is funny
+                     team_id=editors.id
+                     )
 
 # Remove pre-populated labels, add ours.
 for label in repo.get_labels():
@@ -73,12 +75,9 @@ repo.create_label("editorial", "41d366")
 repo.create_label("design", "1d76db")
 repo.create_label("parked", "f9d0c4")
 
-# Create template files
-with open("CONTRIBUTING.md", "w") as F:
-    text = open("contributing.txt").read()
-    F.write(text % vars())
-with open("draft-ietf-%(WGNAME)s-%(DOCNAME)s.md" % vars(), "w") as F:
-    F.write("""---
+initial_files = dict()
+initial_files["CONTRIBUTING.md"] = repo_utils.contributing(wgname=WGNAME)
+initial_files["draft-ietf-%(WGNAME)s-%(DOCNAME)s.md" % vars()] = """---
 docname: draft-ietf-%(WGNAME)s-%(DOCNAME)s-latest
 title: The %(DOCNAME)s draft
 date: {DATE}
@@ -92,25 +91,9 @@ pi: [toc, sortrefs, symrefs]
 --- abstract
 
 Content here.
-""" % vars())
+""" % vars()
 
-DEFAULT_BRANCH = args.default_branch
-
-print("""Run the following commands:
-    git clone https://github.com/%(ORG)s/%(DOC)s
-    cd %(DOC)s
-    git remote set-url origin git@github.com:/ietf-wg-%(WGNAME)s/%(DOC)s
-    git checkout --orphan %(DEFAULT_BRANCH)s
-    cp ../CONTRIBUTING.md .
-    git add CONTRIBUTING.md
-    # If you need an empty draft:
-    cp ../draft-ietf-%(WGNAME)s-%(DOCNAME)s.md .
-    git add %(DOC)s.md
-    git commit -m 'Initial docs' .
-    git push --set-upstream origin %(DEFAULT_BRANCH)s
-    git clone https://github.com/martinthomson/i-d-template lib
-    # MAKE SURE YOU HAVE kramdown ETC INSTALLED!
-    # (See https://github.com/martinthomson/i-d-template/blob/master/doc/SETUP.md)
-    make -f lib/setup.mk
-    git push
-""" % vars())
+repo_utils.clone_and_create_initial_commit(
+    user=ORG, repo=DOC, default_branch=args.default_branch,
+    initial_files=initial_files)
+repo_utils.setup_i_d_template()

--- a/mk-ietf-draft
+++ b/mk-ietf-draft
@@ -4,7 +4,9 @@ Create an IETF WG repository for an I-D
 """
 
 import argparse
+import os.path
 import sys
+
 import ietf_gh_utils as UTILS
 import repo_utils
 
@@ -19,6 +21,8 @@ parser.add_argument('--default-branch', '-b', action='store', default='master',
                     help="Name the primary branch in the repository")
 UTILS.add_gh_auth_arguments(parser)
 args = parser.parse_args(sys.argv[1:])
+
+repo_utils.check_i_d_tools_are_installed()
 
 WGNAME = args.wg
 DOCNAME = args.doc
@@ -50,6 +54,9 @@ ORG = 'ietf-wg-' + WGNAME
 if not UTILS.org_exists(G, ORG):
     raise SystemExit("Organization not found; try mk-ietf-wg")
 o = G.get_organization(ORG)
+
+if os.path.lexists(DOC):
+    sys.exit("Error: destination path '{}' already exists.".format(DOC))
 
 # Create an editors team and populate it
 editors = o.create_team(DOC, privacy='closed')

--- a/mk-ietf-wg
+++ b/mk-ietf-wg
@@ -3,7 +3,10 @@
 Create an IETF WG organization and infrastructure
 """
 
-import argparse, sys
+import argparse
+import os.path
+import sys
+
 import ietf_gh_utils as UTILS
 import repo_utils
 
@@ -24,7 +27,7 @@ CHAIRS = args.chair
 ADS = args.ad
 
 # Login
-G,USER = UTILS.gh_login(args)
+G, USER = UTILS.gh_login(args)
 
 # Verify user names
 if not UTILS.verify_users(G, CHAIRS) or not UTILS.verify_users(G, ADS):
@@ -44,23 +47,25 @@ o.edit(
     company="Internet Engineering Task Force",
     description="The " + WGNAME + " working group",
     email=WGNAME + "@ietf.org"
-    )
+)
 
 # Creates an "owners" team of the chairs and AD's
 owners = o.create_team("owners", privacy='closed')
 owners.add_membership(G.get_user(USER))
-done = [ USER ]
+done = [USER]
 for m in ADS + CHAIRS:
     if m not in done:
         owners.add_membership(G.get_user(m))
-        done += [ m ]
+        done += [m]
 
 # Create a wg-materials repo, owned by the "owners" team.
-REPO="wg-materials"
+REPO = "wg-materials"
+if os.path.lexists(REPO):
+    sys.exit("Error: destination path '{}' already exists.".format(REPO))
 o.create_repo(REPO,
-        description="Repository for meeting materials",
-        has_issues=True, # Probably the default, but this is funny
-        team_id=owners.id)
+              description="Repository for meeting materials",
+              has_issues=True,  # Probably the default, but this is funny
+              team_id=owners.id)
 
 initial_files = {}
 initial_files["CONTRIBUTING.md"] = repo_utils.contributing(wgname=WGNAME)

--- a/mk-ietf-wg
+++ b/mk-ietf-wg
@@ -5,6 +5,7 @@ Create an IETF WG organization and infrastructure
 
 import argparse, sys
 import ietf_gh_utils as UTILS
+import repo_utils
 
 # Parse command line.
 parser = argparse.ArgumentParser(description=__doc__)
@@ -13,6 +14,8 @@ parser.add_argument('--chair', '-c', metavar='GH_ID', action='append', required=
                     help="(can be repeated, must be at least once)")
 parser.add_argument('--ad', '-a', metavar='GH_ID', action='append', required=True,
                     help="(can be repeated, must be at least once)")
+parser.add_argument('--default-branch', '-b', action='store', default='master',
+                    help="Name the primary branch in the repository")
 UTILS.add_gh_auth_arguments(parser)
 args = parser.parse_args(sys.argv[1:])
 
@@ -59,21 +62,11 @@ o.create_repo(REPO,
         has_issues=True, # Probably the default, but this is funny
         team_id=owners.id)
 
-with open("CONTRIBUTING.md", "w") as F:
-    text = open("contributing.txt").read()
-    F.write(text % vars())
-with open("WG-README.md", "w") as F:
-    text = open("wg-readme.txt").read()
-    F.write(text % vars())
+initial_files = {}
+initial_files["CONTRIBUTING.md"] = repo_utils.contributing(wgname=WGNAME)
+text = open("wg-readme.txt").read()
+initial_files["README.md"] = text % vars()
 
-print("""Run the following commands:
-    git clone https://github.com/%(ORG)s/%(REPO)s
-    cd %(REPO)s
-    git remote set-url origin git@github.com:/%(ORG)s/%(REPO)s
-    cp ../CONTRIBUTING.md .
-    git add CONTRIBUTING.md
-    cp ../WG-README.md README.md
-    git add README.md
-    git commit -m 'Initial docs' .
-    git push
-""" % vars())
+repo_utils.clone_and_create_initial_commit(
+    user=ORG, repo=REPO, default_branch=args.default_branch,
+    initial_files=initial_files)

--- a/mk-ind-draft
+++ b/mk-ind-draft
@@ -4,10 +4,9 @@ Create an IETF WG repository for an I-D
 """
 
 import argparse
-import os
 import os.path
-import shutil
 import sys
+
 import ietf_gh_utils as UTILS
 import repo_utils
 
@@ -21,9 +20,7 @@ parser.add_argument('--default-branch', '-b', action='store', default='master',
 UTILS.add_gh_auth_arguments(parser)
 args = parser.parse_args(sys.argv[1:])
 
-if shutil.which("kramdown-rfc2629") is None:
-    sys.exit("Error: Please install kramdown-rfc2629 as described in " +
-             "https://github.com/martinthomson/i-d-template/blob/master/doc/SETUP.md")
+repo_utils.check_i_d_tools_are_installed()
 
 DOCNAME = args.doc
 ASIS = args.asis

--- a/mk-ind-draft
+++ b/mk-ind-draft
@@ -3,7 +3,12 @@
 Create an IETF WG repository for an I-D
 """
 
-import argparse, sys
+import argparse
+import os
+import os.path
+import shutil
+import subprocess
+import sys
 import ietf_gh_utils as UTILS
 
 # Parse command line.
@@ -15,6 +20,10 @@ parser.add_argument('--default-branch', '-b', action='store', default='master',
                     help="Name the primary branch in the repository")
 UTILS.add_gh_auth_arguments(parser)
 args = parser.parse_args(sys.argv[1:])
+
+if shutil.which("kramdown-rfc2629") is None:
+    sys.exit("Error: Please install kramdown-rfc2629 as described in " +
+             "https://github.com/martinthomson/i-d-template/blob/master/doc/SETUP.md")
 
 DOCNAME = args.doc
 ASIS = args.asis
@@ -61,6 +70,9 @@ ORG = USER
 #        done += [ e ]
 # Add the "owners" people?
 
+if os.path.lexists(DOC):
+    sys.exit("Error: destination path '{}' already exists.".format(DOC))
+
 # Create repository draft-$WGNAME-$DOCNAME
 u = G.get_user()
 repo = u.create_repo(DOC,
@@ -74,12 +86,22 @@ repo.create_label("editorial", "41d366")
 repo.create_label("design", "1d76db")
 repo.create_label("parked", "f9d0c4")
 
-# Create template files
-with open("CONTRIBUTING.md", "w") as F:
-    text = open("contributing.txt").read()
-    F.write(text % vars())
-with open("draft-%(WGNAME)s-%(DOCNAME)s.md" % vars(), "w") as F:
-    F.write("""---
+TEMPLATE_DIR = os.path.abspath(os.path.dirname(__file__))
+
+def write_contributing(vars):
+    """Creates a CONTRIBUTING.md from a template and returns its filename."""
+    filename = "CONTRIBUTING.md"
+    with open("CONTRIBUTING.md", "w") as F:
+        text = open(os.path.join(TEMPLATE_DIR, "contributing.txt")).read()
+        F.write(text % vars)
+    return filename
+
+
+def write_initial_draft(vars):
+    """Creates an initial I-D from a template and returns its filename."""
+    filename = "draft-%(WGNAME)s-%(DOCNAME)s.md" % vars
+    with open(filename, "w") as F:
+        F.write("""---
 docname: draft-%(WGNAME)s-%(DOCNAME)s-latest
 title: The %(DOCNAME)s draft
 date: {DATE}
@@ -93,25 +115,24 @@ pi: [toc, sortrefs, symrefs]
 --- abstract
 
 Content here.
-""" % vars())
+""" % vars)
+    return filename
 
-DEFAULT_BRANCH = args.default_branch
 
-print("""Run the following commands:
-    git clone https://github.com/%(ORG)s/%(DOC)s
-    cd %(DOC)s
-    git remote set-url origin git@github.com:/%(WGNAME)s/%(DOC)s
-    git checkout --orphan %(DEFAULT_BRANCH)s
-    cp ../CONTRIBUTING.md .
-    git add CONTRIBUTING.md
-    # If you need an empty draft:
-    cp ../draft-%(WGNAME)s-%(DOCNAME)s.md .
-    git add %(DOC)s.md
-    git commit -m 'Initial docs' .
-    git push --set-upstream origin %(DEFAULT_BRANCH)s
-    git clone https://github.com/martinthomson/i-d-template lib
-    # MAKE SURE YOU HAVE kramdown ETC INSTALLED!
-    # (See https://github.com/martinthomson/i-d-template/blob/master/doc/SETUP.md)
-    make -f lib/setup.mk
-    git push
-""" % vars())
+subprocess.run(["git", "clone", "git@github.com:{}/{}".format(WGNAME, DOC)],
+               check=True)
+os.chdir(DOC)
+subprocess.run(["git", "checkout", "--orphan", args.default_branch],
+               check=True)
+subprocess.run(["git", "add", write_contributing(vars()), write_initial_draft(vars())],
+               check=True)
+subprocess.run(["git", "commit", "-m", "Initial docs"],
+               check=True)
+subprocess.run(["git", "push", "--set-upstream", "origin", args.default_branch],
+               check=True)
+subprocess.run(["git", "clone", "https://github.com/martinthomson/i-d-template", "lib"],
+               check=True)
+subprocess.run(["make", "-f", "lib/setup.mk"],
+               check=True)
+subprocess.run(["git", "push"],
+               check=True)

--- a/mk-ind-draft
+++ b/mk-ind-draft
@@ -7,9 +7,9 @@ import argparse
 import os
 import os.path
 import shutil
-import subprocess
 import sys
 import ietf_gh_utils as UTILS
+import repo_utils
 
 # Parse command line.
 parser = argparse.ArgumentParser(description=__doc__)
@@ -29,16 +29,16 @@ DOCNAME = args.doc
 ASIS = args.asis
 
 # Login
-G,USER = UTILS.gh_login(args)
+G, USER = UTILS.gh_login(args)
 
 # For individual draft, the WGNAME is the USER name
 WGNAME = USER
-EDITORS = [ USER ]
+EDITORS = [USER]
 
 # Fix doc name: remove draft- ietf- $WGNAME- from front
 if not ASIS:
     while True:
-        for prefix in ( 'draft-', 'ietf-', WGNAME+'-'):
+        for prefix in ('draft-', 'ietf-', WGNAME+'-'):
             found = False
             if DOCNAME.startswith(prefix):
                 DOCNAME = DOCNAME[len(prefix):]
@@ -54,17 +54,17 @@ if not UTILS.verify_users(G, EDITORS):
 
 # See if organization exists.
 WGNAME = UTILS.fix_wg_name(WGNAME)
-DOC="draft-" + WGNAME + "-" + DOCNAME
+DOC = "draft-" + WGNAME + "-" + DOCNAME
 ORG = USER
-#if not UTILS.org_exists(G, ORG):
+# if not UTILS.org_exists(G, ORG):
 #    raise SystemExit("Organization not found; try mk-ietf-wg")
-#o = G.get_organization(ORG)
+# o = G.get_organization(ORG)
 
 # Create an editors team and populate it
-#editors = o.create_team(DOC, privacy='closed')
-#editors.add_membership(G.get_user(USER))
-#done = [ USER ]
-#for e in EDITORS:
+# editors = o.create_team(DOC, privacy='closed')
+# editors.add_membership(G.get_user(USER))
+# done = [ USER ]
+# for e in EDITORS:
 #    if e not in done:
 #        editors.add_membership(G.get_user(e))
 #        done += [ e ]
@@ -76,8 +76,8 @@ if os.path.lexists(DOC):
 # Create repository draft-$WGNAME-$DOCNAME
 u = G.get_user()
 repo = u.create_repo(DOC,
-        description="Repository for " + DOC + " draft",
-        )
+                     description="Repository for " + DOC + " draft",
+                     )
 
 # Remove pre-populated labels, add ours.
 for label in repo.get_labels():
@@ -86,22 +86,10 @@ repo.create_label("editorial", "41d366")
 repo.create_label("design", "1d76db")
 repo.create_label("parked", "f9d0c4")
 
-TEMPLATE_DIR = os.path.abspath(os.path.dirname(__file__))
 
-def write_contributing(vars):
-    """Creates a CONTRIBUTING.md from a template and returns its filename."""
-    filename = "CONTRIBUTING.md"
-    with open("CONTRIBUTING.md", "w") as F:
-        text = open(os.path.join(TEMPLATE_DIR, "contributing.txt")).read()
-        F.write(text % vars)
-    return filename
-
-
-def write_initial_draft(vars):
-    """Creates an initial I-D from a template and returns its filename."""
-    filename = "draft-%(WGNAME)s-%(DOCNAME)s.md" % vars
-    with open(filename, "w") as F:
-        F.write("""---
+initial_files = {}
+initial_files["CONTRIBUTING.md"] = repo_utils.contributing(wgname=WGNAME)
+initial_files["draft-%(WGNAME)s-%(DOCNAME)s.md" % vars()] = """---
 docname: draft-%(WGNAME)s-%(DOCNAME)s-latest
 title: The %(DOCNAME)s draft
 date: {DATE}
@@ -115,24 +103,9 @@ pi: [toc, sortrefs, symrefs]
 --- abstract
 
 Content here.
-""" % vars)
-    return filename
+""" % vars()
 
-
-subprocess.run(["git", "clone", "git@github.com:{}/{}".format(WGNAME, DOC)],
-               check=True)
-os.chdir(DOC)
-subprocess.run(["git", "checkout", "--orphan", args.default_branch],
-               check=True)
-subprocess.run(["git", "add", write_contributing(vars()), write_initial_draft(vars())],
-               check=True)
-subprocess.run(["git", "commit", "-m", "Initial docs"],
-               check=True)
-subprocess.run(["git", "push", "--set-upstream", "origin", args.default_branch],
-               check=True)
-subprocess.run(["git", "clone", "https://github.com/martinthomson/i-d-template", "lib"],
-               check=True)
-subprocess.run(["make", "-f", "lib/setup.mk"],
-               check=True)
-subprocess.run(["git", "push"],
-               check=True)
+repo_utils.clone_and_create_initial_commit(
+    user=WGNAME, repo=DOC, default_branch=args.default_branch,
+    initial_files=initial_files)
+repo_utils.setup_i_d_template()

--- a/repo_utils.py
+++ b/repo_utils.py
@@ -1,0 +1,46 @@
+"""Utilities to help initialize repositories."""
+
+import os
+import os.path
+import subprocess
+from typing import Dict
+
+
+TEMPLATE_DIR = os.path.abspath(os.path.dirname(__file__))
+
+
+def contributing(*, wgname: str) -> str:
+    """Returns the contents of a good CONTRIBUTING.md."""
+    text = open(os.path.join(TEMPLATE_DIR, "contributing.txt")).read()
+    return text % {"WGNAME": wgname}
+
+
+def clone_and_create_initial_commit(*, user: str, repo: str, default_branch: str = "master", initial_files: Dict[str, str]) -> None:
+    """Clones the specified repository from Github and creates an initial commit consisting of the |initial_files|.
+
+    Leaves the current directory inside the new checkout.
+    """
+    subprocess.run(["git", "clone", "git@github.com:{}/{}".format(user, repo)],
+                   check=True)
+    os.chdir(repo)
+    subprocess.run(["git", "checkout", "--orphan", default_branch],
+                   check=True)
+    for filename, contents in initial_files.items():
+        with open(filename, "w") as f:
+            f.write(contents)
+    subprocess.run(["git", "add"] + list(initial_files.keys()),
+                   check=True)
+    subprocess.run(["git", "commit", "-m", "Initial docs"],
+                   check=True)
+    subprocess.run(["git", "push", "--set-upstream", "origin", default_branch],
+                   check=True)
+
+
+def setup_i_d_template() -> None:
+    """Sets up martinthomson/i-d-template in the current directory."""
+    subprocess.run(["git", "clone", "https://github.com/martinthomson/i-d-template", "lib"],
+                   check=True)
+    subprocess.run(["make", "-f", "lib/setup.mk"],
+                   check=True)
+    subprocess.run(["git", "push"],
+                   check=True)

--- a/repo_utils.py
+++ b/repo_utils.py
@@ -2,7 +2,9 @@
 
 import os
 import os.path
+import shutil
 import subprocess
+import sys
 from typing import Dict
 
 
@@ -13,6 +15,18 @@ def contributing(*, wgname: str) -> str:
     """Returns the contents of a good CONTRIBUTING.md."""
     text = open(os.path.join(TEMPLATE_DIR, "contributing.txt")).read()
     return text % {"WGNAME": wgname}
+
+
+def check_i_d_tools_are_installed() -> None:
+    """Makes sure any non-Python tools needed to build an I-D are installed.
+
+    Call this early in the main script, before causing side-effects like
+    creating a Github repository, to reduce the chance the user will have to
+    manually undo things because the script failed.
+    """
+    if shutil.which("kramdown-rfc2629") is None:
+        sys.exit("Error: Please install kramdown-rfc2629 as described in " +
+                 "https://github.com/martinthomson/i-d-template/blob/master/doc/SETUP.md")
 
 
 def clone_and_create_initial_commit(*, user: str, repo: str, default_branch: str = "master", initial_files: Dict[str, str]) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PyGithub>=1.43.3
+xml2rfc


### PR DESCRIPTION
Instead of printing shell commands for the user to run.

This also avoids adding files to the initial working directory, which should make it easier to pip-ify these scripts.

It would be possible to use https://gitpython.readthedocs.io/ for a Python interface to Git, but since some of the initialization commands need to be subprocesses anyway, it seemed more straightforward to just call out to the Git utility.